### PR TITLE
fix:remove link from content if it is in LinkPreview

### DIFF
--- a/src/components/FeedSingleTweet.tsx
+++ b/src/components/FeedSingleTweet.tsx
@@ -213,7 +213,9 @@ const FeedSingleTweet = ({
               <div>
                 <div
                   className=""
-                  dangerouslySetInnerHTML={{ __html: content }}
+                  dangerouslySetInnerHTML={{
+                    __html: content.replace(url[0], ""),
+                  }}
                 />
                 <LinkPreview url={url[0]} />
               </div>


### PR DESCRIPTION
Remove link from the content if link is in LinkPreview.

![image](https://user-images.githubusercontent.com/103769012/190902045-78010040-4b4f-49b5-8cc9-82685b8a8aea.png)
