### PR TITLE
feat: web socket example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 REACT_APP_SERVER_URL=http://localhost:3001
+REACT_APP_WEBSOCKET_URL=ws://localhost:3002

--- a/src/pages/Explore.tsx
+++ b/src/pages/Explore.tsx
@@ -1,10 +1,27 @@
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import Layout from "../containers/Layout";
 
+const wsURI = process.env.REACT_APP_WEBSOCKET_URL;
+const ws = new WebSocket(wsURI || "");
+
 const ExplorePage: React.FunctionComponent = () => {
+  const [messages, setMessages] = useState<string[]>([]);
+  ws.onopen = () => setMessages(["connected", ...messages]);
+  ws.onmessage = (currentMessage) =>
+    setMessages([currentMessage.data, ...messages]);
   const { t } = useTranslation();
-  return <Layout title={t("pageTitles:explorePage")}>Explore</Layout>;
+  return (
+    <Layout title={t("pageTitles:explorePage")}>
+      Explore
+      <li>
+        {messages.map((currentMessage, index) => (
+          <ul key={index}>{currentMessage}</ul>
+        ))}
+      </li>
+    </Layout>
+  );
 };
 
 export default ExplorePage;


### PR DESCRIPTION
some example of work with webSosckets. On free page "Explore" - show all info from webSocket

- if you run two different frontend and send  tweet at one page, on the second page you will see this structure of tweet at page "Explore" if this page will be open
- Don't save this info in any storage, that is why now you don't see any info on page "Explore" if this page not active
- need to fill .env: REACT_APP_WEBSOCKET_URL=ws://localhost:3002

![image](https://user-images.githubusercontent.com/103836064/190926588-cff79ba4-d807-461d-949e-58cfbd221d52.png)
